### PR TITLE
Fix API documents 

### DIFF
--- a/APIs/AnnotationAPI.raml
+++ b/APIs/AnnotationAPI.raml
@@ -132,7 +132,7 @@ documentation:
         200:
           body:
             example: !include ../examples/annotationapi-node-resources-get-200.json
-            type: Flows
+            type: Resources
     /{flowId}:
       uriParameters:
         flowId:
@@ -144,7 +144,7 @@ documentation:
           200:
             body:
               example: !include ../examples/annotationapi-node-resource-get-200.json
-              type: Flow
+              type: Resource
           404:
             description: Returned when the requested Flow ID does not exist
             body:
@@ -187,7 +187,7 @@ documentation:
         200:
           body:
             example: !include ../examples/annotationapi-node-resources-get-200.json
-            type: Devices
+            type: Resources
     /{deviceId}:
       uriParameters:
         deviceId:
@@ -199,7 +199,7 @@ documentation:
           200:
             body:
               example: !include ../examples/annotationapi-node-resource-get-200.json
-              type: Device
+              type: Resource
           404:
             description: Returned when the requested Device ID does not exist
             body:
@@ -242,7 +242,7 @@ documentation:
         200:
           body:
             example: !include ../examples/annotationapi-node-resources-get-200.json
-            type: Senders
+            type: Resources
     /{senderId}:
       uriParameters:
         senderId:
@@ -254,7 +254,7 @@ documentation:
           200:
             body:
               example: !include ../examples/annotationapi-node-resource-get-200.json
-              type: Sender
+              type: Resource
           404:
             description: Returned when the requested Sender ID does not exist
             body:
@@ -297,7 +297,7 @@ documentation:
         200:
           body:
             example: !include ../examples/annotationapi-node-resources-get-200.json
-            type: Receivers
+            type: Resources
     /{receiverId}:
       uriParameters:
         receiverId:

--- a/APIs/schemas/annotationapi-base.json
+++ b/APIs/schemas/annotationapi-base.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
+  "type": "array",
   "description": "Describes the Annotation API base resource",
   "title": "Annotation API base resource",
   "items": {

--- a/APIs/schemas/annotationapi-node-base.json
+++ b/APIs/schemas/annotationapi-node-base.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
+  "type": "array",
   "description": "Describes the Annotation API node resource",
   "title": "Annotation API node resource",
   "items": {


### PR DESCRIPTION
- raml: always point at the same `Resource(s)` schema since everything is a resource.
- schemas: fix types